### PR TITLE
Adding minCohortBiomass to Biomass_core parameters

### DIFF
--- a/Biomass_speciesFactorial.R
+++ b/Biomass_speciesFactorial.R
@@ -236,7 +236,8 @@ RunExperiment <- function(speciesTableFactorial, maxBInFactorial, knownDigest, f
       seedingAlgorithm = "noSeeding",
       sppEquivCol = "B_factorial",
       successionTimestep = 10,
-      vegLeadingProportion = 0
+      vegLeadingProportion = 0,
+      minCohortBiomass = 1
     )
   )
 


### PR DESCRIPTION
Now that `minCohortBiomass` works within `Biomass_core`, we need to set it when doing the factorial simulations. Without setting it, all cohorts are removed from `cohortData` since we initialize all biomass to 1. 

Tried the fix, and seems to work:

_before:_
![cohortFactorial_2025-05-12 15_27_20](https://github.com/user-attachments/assets/0eb542c0-062f-4e2a-aed7-3d294b3d6f33)

_after:_
![cohortFactorial_2025-05-14 11_01_17](https://github.com/user-attachments/assets/92df2a47-eee8-4f3d-b3b1-32b58c052e1a)
