### PR TITLE
Change SpaDES.project pointer.

### DIFF
--- a/Biomass_speciesFactorial.R
+++ b/Biomass_speciesFactorial.R
@@ -236,7 +236,8 @@ RunExperiment <- function(speciesTableFactorial, maxBInFactorial, knownDigest, f
       seedingAlgorithm = "noSeeding",
       sppEquivCol = "B_factorial",
       successionTimestep = 10,
-      vegLeadingProportion = 0
+      vegLeadingProportion = 0,
+      minCohortBiomass = 1
     )
   )
 


### PR DESCRIPTION
Previously, `Require` was installing `SpaDES.project@main` which, in term, depends on `PredictiveEcology/Require@simplify4` which does not exist anymore. It was triggering this error when called within a `setupProject()`:

```
Installing any missing reqdPkgs
SpaDES.core (>= 2.1.4), LandR not on CRAN; checking CRAN archives ...
    Done evaluating archives!
cannot open URL 'https://raw.githubusercontent.com/PredictiveEcology/Require/simplify4/DESCRIPTION'
Error in .downloadFileMasterMainAuthWithHandlers(Account, Package, Branch,  :
  The following repository does not seem to exist:
PredictiveEcology/Require@simplify4
Did you spell the GitHub.com repository, package and or branch/gitRefs correctly?
```